### PR TITLE
unfortuneatly va_start macro does not accept references - on MSVC 19 …

### DIFF
--- a/src/console/interfaces/output_interface.h
+++ b/src/console/interfaces/output_interface.h
@@ -44,67 +44,67 @@ namespace Console {
             /**
              * Write a string to the console.
              *
-             * @param const std::string & message
+             * @param const std::string message
              * @param ... any
              * @return void
              */
-            virtual void write(const std::string & message, ...) = 0;
+            virtual void write(const std::string message, ...) = 0;
 
             /**
              * Write a colored string to the console.
              *
              * @param Types::Colors color
-             * @param const std::string & message
+             * @param const std::string message
              * @param ... any
              * @return void
              */
-            virtual void write(Types::Colors color, const std::string & message, ...) = 0;
+            virtual void write(Types::Colors color, const std::string message, ...) = 0;
 
             /**
              * Write a line to the console.
              *
-             * @param const std::string & line
+             * @param const std::string line
              * @param ... any
              * @return void
              */
-            virtual void writeLine(const std::string & line, ...) = 0;
+            virtual void writeLine(const std::string line, ...) = 0;
 
             /**
              * Write a colored line to the console.
              *
              * @param Types::Colors color
-             * @param const std::string & line
+             * @param const std::string line
              * @param ... any
              * @return void
              */
-            virtual void writeLine(Types::Colors color, const std::string & line, ...) = 0;
+            virtual void writeLine(Types::Colors color, const std::string line, ...) = 0;
 
             /**
              * Write an error to the console.
              *
-             * @param const std::string & line
+             * @param const std::string line
              * @param ... any
              * @return void
              */
-            virtual void error(const std::string & line, ...) = 0;
+            virtual void error(const std::string line, ...) = 0;
 
             /**
              * Write an info to the console.
              *
-             * @param const std::string & line
+             * @param const std::string line
              * @param ... any
              * @return void
              */
-            virtual void info(const std::string & line, ...) = 0;
+            virtual void info(const std::string line, ...) = 0;
 
             /**
              * Write a warning to the console.
              *
-             * @param const std::string & line
+             * @param const std::string line
              * @param ... any
              * @return void
              */
-            virtual void warning(const std::string & line, ...) = 0;
+            virtual void warning(const std::string line, ...) = 0;
 
             /**
              * Create a progress bar instance.

--- a/src/console/output.h
+++ b/src/console/output.h
@@ -39,21 +39,21 @@ namespace Console {
         /**
          * Write a string to the console.
          *
-         * @param const std::string & line
+         * @param const std::string line
          * @param ... any
          * @return void
          */
-        void write(const std::string & message, ...) override;
+        void write(const std::string message, ...) override;
 
         /**
          * Write a colored string to the console.
          *
          * @param Types::Colors color
-         * @param const std::string & message
+         * @param const std::string message
          * @param ... any
          * @return void
          */
-        void write(Types::Colors color, const std::string & message, ...) override;
+        void write(Types::Colors color, const std::string message, ...) override;
 
         /**
          * Write a line to the console.
@@ -62,44 +62,44 @@ namespace Console {
          * @param ... any
          * @return void
          */
-        void writeLine(const std::string & line, ...) override;
+        void writeLine(const std::string line, ...) override;
 
         /**
          * Write a colored line to the console.
          *
          * @param Types::Colors color
-         * @param const std::string & line
+         * @param const std::string line
          * @param ... any
          * @return void
          */
-        void writeLine(Types::Colors color, const std::string & line, ...) override;
+        void writeLine(Types::Colors color, const std::string line, ...) override;
 
         /**
          * Write an error to the console.
          *
-         * @param const std::string & line
+         * @param const std::string line
          * @param ... any
          * @return void
          */
-        void error(const std::string & line, ...) override;
+        void error(const std::string line, ...) override;
 
         /**
          * Write an info to the console.
          *
-         * @param const std::string & line
+         * @param const std::string line
          * @param ... any
          * @return void
          */
-        void info(const std::string & line, ...) override;
+        void info(const std::string line, ...) override;
 
         /**
          * Write a warning to the console.
          *
-         * @param const std::string & line
+         * @param const std::string line
          * @param ... any
          * @return void
          */
-        void warning(const std::string & line, ...) override;
+        void warning(const std::string line, ...) override;
 
         /**
          * Create a progress bar instance.

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -76,11 +76,11 @@ void Output::printCommandHelp(Interfaces::CommandInterface * command)
 /**
  * Write a string to the console.
  *
- * @param const std::string & message
+ * @param const std::string message
  * @param ...
  * @return void
  */
-void Output::write(const std::string & message, ...)
+void Output::write(const std::string message, ...)
 {
     va_list args;
 
@@ -93,11 +93,11 @@ void Output::write(const std::string & message, ...)
  * Write a colored string to the console.
  *
  * @param Types::Colors color
- * @param const std::string & message
+ * @param const std::string message
  * @param ... any
  * @return void
  */
-void Output::write(Types::Colors color, const std::string & message, ...)
+void Output::write(Types::Colors color, const std::string message, ...)
 {
     va_list args;
 
@@ -162,11 +162,11 @@ void Output::write(Types::Colors color, const std::string & message, ...)
 /**
  * Write a line to the console.
  *
- * @param const std::string & line
+ * @param const std::string line
  * @param ... any
  * @return void
  */
-void Output::writeLine(const std::string & line, ...)
+void Output::writeLine(const std::string line, ...)
 {
     va_list args;
 
@@ -181,11 +181,11 @@ void Output::writeLine(const std::string & line, ...)
  * Write a colored line to the console.
  *
  * @param Types::Colors color
- * @param const std::string & line
+ * @param const std::string line
  * @param ... any
  * @return void
  */
-void Output::writeLine(Types::Colors color, const std::string & line, ...)
+void Output::writeLine(Types::Colors color, const std::string line, ...)
 {
     va_list args;
 
@@ -252,11 +252,11 @@ void Output::writeLine(Types::Colors color, const std::string & line, ...)
 /**
  * Write an error to the console.
  *
- * @param const std::string & line
+ * @param const std::string line
  * @param ... any
  * @return void
  */
-void Output::error(const std::string & line, ...)
+void Output::error(const std::string line, ...)
 {
     va_list args;
 
@@ -281,11 +281,11 @@ void Output::error(const std::string & line, ...)
 /**
  * Write an info to the console.
  *
- * @param const std::string & line
+ * @param const std::string line
  * @param ... any
  * @return void
  */
-void Output::info(const std::string & line, ...)
+void Output::info(const std::string line, ...)
 {
     va_list p_args;
 
@@ -299,11 +299,11 @@ void Output::info(const std::string & line, ...)
 /**
  * Write a warning to the console.
  *
- * @param const std::string & line
+ * @param const std::string line
  * @param ... any
  * @return void
  */
-void Output::warning(const std::string & line, ...)
+void Output::warning(const std::string line, ...)
 {
     va_list args;
 


### PR DESCRIPTION
…it throws a compile-time error.

issue:
@see https://stackoverflow.com/questions/3184401/varargsva-list-va-start-doesnt-work-with-pass-by-reference-parameter